### PR TITLE
supported JRE/JDK should be not 1.7 but 1.8

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 
 <p>SpotBugs is the spiritual successor of <a href="http://findbugs.sourceforge.net/">FindBugs</a>, carrying on from the point where it left off with support of its community.</p>
 
-<p>SpotBugs requires JRE (or JDK) 1.7.0 or later to run.  However, it can analyze programs compiled for any version of Java, from 1.0 to 1.8.</p>
+<p>SpotBugs requires JRE (or JDK) 1.8.0 or later to run.  However, it can analyze programs compiled for any version of Java, from 1.0 to 1.8.</p>
 
 <h3>
 <a id="bug-descriptions" class="anchor" href="#bug-descriptions" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Bug Descriptions</h3>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 
 <p>SpotBugs is the spiritual successor of <a href="http://findbugs.sourceforge.net/">FindBugs</a>, carrying on from the point where it left off with support of its community.</p>
 
-<p>SpotBugs requires JRE (or JDK) 1.8.0 or later to run.  However, it can analyze programs compiled for any version of Java, from 1.0 to 1.8.</p>
+<p>SpotBugs requires JRE (or JDK) 1.8.0 or later to run.  However, it can analyze programs compiled for any version of Java, from 1.0 to 1.9.</p>
 
 <h3>
 <a id="bug-descriptions" class="anchor" href="#bug-descriptions" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Bug Descriptions</h3>
@@ -83,7 +83,7 @@
       </div>
     </div>
 
-  
+
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
It seems that first SpotBugs release [doesn't support 1.7](https://github.com/spotbugs/spotbugs/issues/19), then it's better to update this page.


