### PR TITLE
Introduce submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "build"]
+	path = build
+	url = git@github.com:spotbugs/spotbugs.github.io.git


### PR DESCRIPTION
## Problem

- We put both of source and generated files (HTML, CSS, images, etc.) to the same branch, so our diff in PR becomes really dirty

## Solution in this pull request

This PR adds a `build` directory, which works as a Git submodule.
Later we can add more PR to delete generated files from `master` branch.

I also pushed `gh-pages` branch to this repository, which has the same content with `master` branch. We can use `gh-pages` this page to host static pages instead of `master` branch.

refs: https://github.com/shiftyp/submodule-gh-pages-example