### PR TITLE
link to Maven plugin

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
 
 <ul>
 <li><a href="http://spotbugs.readthedocs.io/en/latest/ant.html">Ant</a></li>
-<li><a href="http://gleclaire.github.io/findbugs-maven-plugin/">Maven</a></li>
+<li><a href="https://github.com/hazendaz/findbugs-maven-plugin/tree/spotbugs">Maven</a></li>
 <li><a href="https://plugins.gradle.org/plugin/com.github.spotbugs">Gradle</a></li>
 <li><a href="http://spotbugs.readthedocs.io/en/latest/eclipse.html">Eclipse</a></li>
 </ul>


### PR DESCRIPTION
Now we recommend to use forked findbugs-maven-plugin for SpotBugs, then link to @hazendaz's repository instead of findbugs-maven-plugin official site.

ref: https://github.com/spotbugs/spotbugs/issues/8#issuecomment-312501877