### PR TITLE
Define license of logo & icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <body>
     <header>
       <div class="inner">
-        <h1><a href="/index.html">SpotBugs <img src="spotbugs-icon.png" /></a></h1>
+        <h1><a href="/index.html">SpotBugs <img src="images/logos/spotbugs_icon_only_zoom_256px.png" width="80" height="80" /></a></h1>
         <h2>Find bugs in Java Programs</h2>
         <a href="https://github.com/spotbugs/spotbugs" class="button"><small>Check it out on</small> GitHub</a>
       </div>
@@ -67,10 +67,22 @@
 <p><a href="https://javadoc.io/doc/com.github.spotbugs/spotbugs/">API</a> [<a href="https://javadoc.io/page/com.github.spotbugs/spotbugs/latest/overview-summary.html">no frames</a>]</p>
 
 <h3>
+<a id="logo-license" class="anchor" href="#logo-license" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>License of SpotBugs Logo</h3>
+
+<p>Following SpotBugs Logos and Icons are licensed under <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>.</p>
+
+<ul>
+<li><a href="images/logos/spotbugs_logo_300px.png">Logo (300px)</a></li>
+<li><a href="images/logos/spotbugs_logo_600px.png">Logo (600px)</a></li>
+<li><a href="images/logos/spotbugs_icon_only_zoom_256px.png">Icon (256px)</a></li>
+<li><a href="images/logos/spotbugs_icon_only_385px.png">Icon (385px)</a></li>
+</ul>
+
+<h3>
 <a id="support-or-contact" class="anchor" href="#support-or-contact" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Support or Contact</h3>
 
 <p>You can report issues on <a href="https://github.com/spotbugs/spotbugs/issues">GitHub</a>.</p>
-          
+
 <p>Or, you can contact us using <a href="https://github.com/spotbugs/discuss/issues?q=">our general purpose mailing list</a>.</p>
 
         </section>
@@ -80,6 +92,7 @@
             <li><a href="#bug-descriptions">Bug Descriptions</a></li>
             <li><a href="#using-spotbugs">Using SpotBugs</a></li>
             <li><a href="#extensions">Extensions</a></li>
+            <li><a href="#logo-license">License of SpotBugs Logo</a></li>
             <li><a href="#support-or-contact">Support or Contact</a></li>
           </ul>
         </aside>


### PR DESCRIPTION
Refer https://github.com/spotbugs/discuss/issues/6. Current idea is use CC BY 4.0 as license of logo & icon.
I also change the icon in the https://spotbugs.github.io/ to use the latest icon.

These logo is introduced at https://github.com/spotbugs/spotbugs/issues/36,
so let me ask @h3xstream to review this PR.