### PR TITLE
Clarify relationship of SpotBugs to FindBugs

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
         <section id="main-content" class="two-column">
           <p>SpotBugs is a program which uses static analysis to look for bugs in Java code.  It is free software, distributed under the terms of the <a href="http://www.gnu.org/licenses/lgpl.html">GNU Lesser General Public License</a>.</p>
 
-<p>SpotBugs is a fork of <a href="http://findbugs.sourceforge.net/">FindBugs</a>, carrying on from the point where it left off with support of its community. Please check <a href="http://spotbugs.readthedocs.io/en/latest/">the official manual</a> for details.</p>
+<p>SpotBugs is a fork of <a href="http://findbugs.sourceforge.net/">FindBugs</a> (which is now a dead project), carrying on from the point where it left off with support of its community. Please check <a href="http://spotbugs.readthedocs.io/en/latest/">the official manual</a> for details.</p>
 
 <p>SpotBugs requires JRE (or JDK) 1.8.0 or later to run.  However, it can analyze programs compiled for any version of Java, from 1.0 to 1.9.</p>
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
         <section id="main-content" class="two-column">
           <p>SpotBugs is a program which uses static analysis to look for bugs in Java code.  It is free software, distributed under the terms of the <a href="http://www.gnu.org/licenses/lgpl.html">GNU Lesser General Public License</a>.</p>
 
-<p>SpotBugs is a fork of <a href="http://findbugs.sourceforge.net/">FindBugs</a> (which is now a dead project), carrying on from the point where it left off with support of its community. Please check <a href="http://spotbugs.readthedocs.io/en/latest/">the official manual</a> for details.</p>
+<p>SpotBugs is a fork of <a href="http://findbugs.sourceforge.net/">FindBugs</a> (which is now an abandoned project), carrying on from the point where it left off with support of its community. Please check <a href="http://spotbugs.readthedocs.io/en/latest/">the official manual</a> for details.</p>
 
 <p>SpotBugs requires JRE (or JDK) 1.8.0 or later to run.  However, it can analyze programs compiled for any version of Java, from 1.0 to 1.9.</p>
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
         <section id="main-content" class="two-column">
           <p>SpotBugs is a program which uses static analysis to look for bugs in Java code.  It is free software, distributed under the terms of the <a href="http://www.gnu.org/licenses/lgpl.html">GNU Lesser General Public License</a>.</p>
 
-<p>SpotBugs is the spiritual successor of <a href="http://findbugs.sourceforge.net/">FindBugs</a>, carrying on from the point where it left off with support of its community. Please check <a href="http://spotbugs.readthedocs.io/en/latest/">the official manual</a> for details.</p>
+<p>SpotBugs is a fork of <a href="http://findbugs.sourceforge.net/">FindBugs</a>, carrying on from the point where it left off with support of its community. Please check <a href="http://spotbugs.readthedocs.io/en/latest/">the official manual</a> for details.</p>
 
 <p>SpotBugs requires JRE (or JDK) 1.8.0 or later to run.  However, it can analyze programs compiled for any version of Java, from 1.0 to 1.9.</p>
 


### PR DESCRIPTION
As noted in https://github.com/spotbugs/spotbugs.github.io/issues/24, the text "spiritual successor" is confusing.
This pull request clarifies the documentation:  SpotBugs is a fork of FindBugs.