### PR TITLE
Update supported Java versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,14 +31,14 @@
 
 <p>SpotBugs is a fork of <a href="http://findbugs.sourceforge.net/">FindBugs</a> (which is now an abandoned project), carrying on from the point where it left off with support of its community. Please check <a href="http://spotbugs.readthedocs.io/en/latest/">the official manual</a> for details.</p>
 
-<p>SpotBugs requires JRE (or JDK) 1.8.0 or later to run.  However, it can analyze programs compiled for any version of Java, from 1.0 to 1.9.</p>
+<p>SpotBugs requires JRE (or JDK) 1.8.0 or later to run.  However, it can analyze programs compiled for any version of Java, from 1.0 to 21.</p>
 
 <h3>
 <a id="bug-descriptions" class="anchor" href="#bug-descriptions" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Bug Descriptions</h3>
 
-<p>SpotBugs checks for more than 400 bug patterns. Bug descriptions can be found <a href="https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html">here</a></p>
+<p>SpotBugs checks for more than 400 bug patterns. Bug descriptions can be found <a href="https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html">here</a>.</p>
 
-<p>Descriptions are also available in <a href="https://spotbugs.readthedocs.io/ja/latest/bugDescriptions.html">Japanese</a></p>
+<p>Descriptions are also available in <a href="https://spotbugs.readthedocs.io/ja/latest/bugDescriptions.html">Japanese</a>.</p>
 
 <h3>
 <a id="using-spotbugs" class="anchor" href="#using-spotbugs" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Using SpotBugs</h3>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 
 <p>SpotBugs is a fork of <a href="http://findbugs.sourceforge.net/">FindBugs</a> (which is now an abandoned project), carrying on from the point where it left off with support of its community. Please check <a href="http://spotbugs.readthedocs.io/en/latest/">the official manual</a> for details.</p>
 
-<p>SpotBugs requires JRE (or JDK) 1.8.0 or later to run.  However, it can analyze programs compiled for any version of Java, from 1.0 to 21.</p>
+<p>SpotBugs requires JRE (or JDK) 1.8.0 or later to run.  However, it can analyze programs compiled for any version of Java.</p>
 
 <h3>
 <a id="bug-descriptions" class="anchor" href="#bug-descriptions" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Bug Descriptions</h3>


### PR DESCRIPTION
Updating the supported Java versions, as it seems to be stuck on 1.9, however SpotBugs can analyze even Java 21 programs.