### PR TITLE
Add SonarQube and IntelliJ integration links

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,8 @@
 <li><a href="http://spotbugs.readthedocs.io/en/latest/maven.html">Maven</a></li>
 <li><a href="http://spotbugs.readthedocs.io/en/latest/gradle.html">Gradle</a></li>
 <li><a href="http://spotbugs.readthedocs.io/en/latest/eclipse.html">Eclipse</a></li>
+<li><a href="https://github.com/spotbugs/sonar-findbugs">SonarQube</a></li>
+<li><a href="https://github.com/JetBrains/spotbugs-intellij-plugin">IntelliJ IDEA</a></li>
 </ul>
 
 To automatically configure the Eclipse SpotBugs plugin from the SpotBugs Maven plugin configuration, use <a href="https://github.com/m2e-code-quality/m2e-code-quality/">m2e-code-quality</a>.


### PR DESCRIPTION
The Sonarqube and IntelliJ integration links are refered in the project's [readme](https://github.com/spotbugs/spotbugs/blob/master/README.md), but it's missing from here.